### PR TITLE
Add support for curved monitors

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,15 @@
 			  <option value="3">Triple Screens</option>
 			</select>
 
+			<label for="curved">Curved screens </label>
+			<input type="checkbox" name="curved" id="curved" />
+
+			<label for="radius">Radius of curve (mm)</label>
+			<div id="radiusSlider">
+				<div id="radius-handle" class="ui-slider-handle myhandle"></div>
+			</div>
+			<input type="hidden" id="radius" />
+
 			<label for="bezelSlider">Bezel Thickness for Triple Screen (mm)</label>
 			<div id="bezelSlider">
 				<div id="bezel-handle" class="ui-slider-handle myhandle"></div>

--- a/script.js
+++ b/script.js
@@ -166,11 +166,11 @@ $(document).ready(function() {
 		max: 3000,
 		step: 10,
 		create: function() {
-			radiusHandle.text("R"+$(this).slider("value"));
+			radiusHandle.text($(this).slider("value")+"R");
 			$("#radius").val($(this).slider("value"));
 		},
 		slide: function(event, ui) {
-			radiusHandle.text("R"+ui.value);
+			radiusHandle.text(ui.value+"R");
 			$("#radius").val(ui.value);
 			calculateFOV();
 		}

--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@ body>div:first-child {
 	flex-wrap: wrap;
 }
 
-#screensize-handle, #distance-handle, #bezel-handle {
+#screensize-handle, #distance-handle, #bezel-handle, #radius-handle {
 	width: 2em;
 	height: 1.5em;
 	top: 50%;
@@ -17,6 +17,10 @@ body>div:first-child {
 	margin-left: -1em;
 	text-align: center;
 	line-height: 1.5em;
+}
+
+#radius-handle {
+	width: 4em;
 }
 
 label {


### PR DESCRIPTION
With option off, previous values are returned.

Fixes https://github.com/dinex86/FOV-Calculator/issues/9

I also replaced the trigonometry for width calculation with Pythagoras; this was mostly for debugging and seeing if I could simplify some of the math, but it should be slightly more efficient anyway so I left this change in.

This is a significant improvement for me on a Neo G9 at 75CM (49" 32:9 R1000), changing hFov from 77deg to 89deg; there's probably a matter of preference and just plain what people are used to, especially as - like flat monitors - the theoretically vFov changes left-to-right - but this gives people the option.